### PR TITLE
Revert to default pgf external mode (close #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@
     \dlutset{pgf/externalmainfile=DLUTThesis}
     ```
 
-2. 正文部分需要插入tikz图形的部分，以如下格式插入图形
+1. 在正文需要插入tikz图形的位置，以如下格式插入图形
 
     ```latex
     \begin{figure}[!htbp]
@@ -83,17 +83,31 @@
     \end{figure}%
     ```
 
-3. 预绘制图形（以`xelatex`命令为例）
+1. 编译主文档
+
+    ```shell
+    xelatex -shell-escape DLUTThesis.tex
+    ```
+
+    默认采用增量编译的预绘制模式，即每次只重新绘制改动过的tikz图形。
+
+1. （可选）进阶使用
+
+    用户还可手动修改预绘制模式，例如在preamble如下设置后，
+
+    ```latex
+    \dlutset{
+    	pgf/externalmode=list and make
+    }
+    ```
+
+    就支持先单独编译每个tikz图形（以下 `pdf-filename` 代表插入tikz图形时设置的pdf文件名），再编译主文档。
 
     ```shell
     xelatex -shell-escape -halt-on-error -interaction=batchmode -jobname "pdf-filename" "DLUTThesis"
     ```
 
-4. 主文档中插入图形
-
-    ```shell
-    xelatex -shell-escape DLUTThesis.tex
-    ```
+    选项 `pgf/externalmode` 是pgf选项 `/tikz/external/mode` 的别名，完整用法可查询pgf文档。
 
 ### 参考文献及其引用
 

--- a/dlutthesis.cls
+++ b/dlutthesis.cls
@@ -950,20 +950,20 @@
 	/dlut/.cd,
 	%% - Key to enable the externalisation
 	pgf/makeexternalfig/.code={\cmd@dlut@pgf@export@fig},
-    %% - Key for changing the prefix of the externalising file name
+	%% - Key for changing the prefix of the externalising file name
 	pgf/externalprefix/.code={\tikzsetexternalprefix{#1}},
-    %% - Key for activing the externalisation and specifying the file name
+	%% - Key for activing the externalisation and specifying the file name
 	pgf/makenextfig/.code={\cmd@dlut@pgf@export@fig\tikzsetnextfilename{#1}},
 	%% - Declare an option key to control the activity of externalisation
 	pgf/externalising/.is if=@dlut@pgf@externalexpensive,
-    %%   - Default, true
+	%%   - Default, true
 	pgf/externalising/.default=true,
-    %% - Key for specifying the main document (\jobname).
-    %%   Note that this key has to be set to the name of your main document in
-    %%   the preamble. The externalising is actived after setting up by default.
+	%% - Key for specifying the main document (\jobname).
+	%%   Note that this key has to be set to the name of your main document in
+	%%   the preamble. The externalising is actived after setting up by default.
 	pgf/externalmainfile/.code={\@dlut@pgf@externalmainfile@set{#1}},
-    pgf/externalmainfile/.default=DLUTThesis,
-    % pgf/externalmainfile/.initial=DLUTThesis,
+	pgf/externalmainfile/.default=DLUTThesis,
+	% pgf/externalmainfile/.initial=DLUTThesis,
 	%% - Key to set the external mode, merely an alias
 	pgf/externalmode/.forward to=/tikz/external/mode
 }

--- a/dlutthesis.cls
+++ b/dlutthesis.cls
@@ -889,7 +889,6 @@
         \tikzexternalize[
             prefix=Figs/pdf/pgf-ex-,
             export=false, %% needs to be activated individually
-            mode=list and make,
             verbose IO=false,
             % export=true, %% FASTER FOR DEBUGGING
         ]
@@ -916,7 +915,6 @@
         \tikzexternalize[%
             prefix=Figs/pdf/pgf-ex-,
             export=false,  %$ needs to be activated individually
-            mode=list and make,
             verbose IO=false,
             % export=true, %% FASTER FOR DEBUGGING
         ]{#1}
@@ -966,6 +964,8 @@
 	pgf/externalmainfile/.code={\@dlut@pgf@externalmainfile@set{#1}},
     pgf/externalmainfile/.default=DLUTThesis,
     % pgf/externalmainfile/.initial=DLUTThesis,
+	%% - Key to set the external mode, merely an alias
+	pgf/externalmode/.forward to=/tikz/external/mode
 }
 
 %%   - Solve the incompatible issue of biblatex (defernumbers) and pgf/TikZ


### PR DESCRIPTION
Main changes:

1. delete explicit mode change
1. add key "/dlut/pgf/externalmode" as alias of "/pgf/external/mode"
1. update readme
1. unify indent char to tab

In order to make this latex template more user friendly.